### PR TITLE
Add HTTP streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A FastAPI application that demonstrates Server-Sent Events (SSE) integration wit
 
 ## Overview
 
-This project showcases how to use Server-Sent Events (SSE) as a transport layer for MCP in a FastAPI application. It provides a simple echo service that can:
+This project showcases how to use Server-Sent Events (SSE) and simple HTTP streaming as transport layers for MCP in a FastAPI application. It provides a simple echo service that can:
 
 - Handle FastAPI HTTP requests
 - Implement MCP tools, resources and prompts using the MCP python-sdk
@@ -43,10 +43,12 @@ The server will be available at http://127.0.0.1:8000.
 - `GET /` - Returns a simple JSON greeting
 - `GET /sse/` - SSE endpoint for establishing connections
 - `POST /messages/` - Endpoint for sending messages over SSE
+- `GET /http/stream/` - HTTP streaming endpoint
+- `POST /http/messages/` - Endpoint for sending messages over HTTP streaming
 
 ## Examples
 
-The application provides three example MCP functions:
+The application provides three example MCP functions and now supports HTTP streaming:
 
 1. **Tool Function**: Echoes messages
    ```python

--- a/app/http_stream.py
+++ b/app/http_stream.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
+from contextlib import asynccontextmanager
+from starlette.types import Receive, Scope, Send
+from starlette.responses import StreamingResponse, Response
+from starlette.requests import Request
+from uuid import uuid4, UUID
+import anyio
+from anyio.streams.memory import (
+    MemoryObjectReceiveStream,
+    MemoryObjectSendStream,
+)
+import mcp.types as types
+import json
+
+
+class NDJSONResponse(StreamingResponse):
+    """Streaming response for newline delimited JSON."""
+
+    def __init__(self, content):
+        super().__init__(content, media_type="application/x-ndjson")
+
+
+class HttpStreamServerTransport:
+    """Simple HTTP streaming transport using newline delimited JSON."""
+
+    def __init__(self, endpoint: str) -> None:
+        self._endpoint = endpoint
+        self._read_stream_writers: dict[UUID, MemoryObjectSendStream] = {}
+
+    async def handle_post_message(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
+        request = Request(scope, receive)
+        session_param = request.query_params.get("session_id")
+        if not session_param:
+            await Response(status_code=400)(scope, receive, send)
+            return
+        session_id = UUID(session_param)
+        writer = self._read_stream_writers.get(session_id)
+        if writer is None:
+            await Response(status_code=404)(scope, receive, send)
+            return
+        data = await request.json()
+        # TODO: parse JSONRPCMessage correctly when mcp.types is available
+        await writer.send(types.JSONRPCMessage(**data))
+        await Response(status_code=204)(scope, receive, send)
+
+    @asynccontextmanager
+    async def connect_stream(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> tuple[
+        MemoryObjectReceiveStream[types.JSONRPCMessage | Exception],
+        MemoryObjectSendStream[types.JSONRPCMessage],
+    ]:
+        if scope["type"] != "http":
+            raise ValueError("connect_stream can only handle HTTP requests")
+
+        read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
+        write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+
+        session_id = uuid4()
+        session_uri = f"{self._endpoint}?session_id={session_id.hex}"
+        self._read_stream_writers[session_id] = read_stream_writer
+
+        async def iter_content():
+            yield json.dumps({"endpoint": session_uri}) + "\n"
+            async for message in write_stream_reader:
+                yield (
+                    json.dumps(
+                        message.model_dump(by_alias=True, exclude_none=True)
+                    )
+                    + "\n"
+                )
+
+        response = NDJSONResponse(iter_content())
+        await response(scope, receive, send)
+        try:
+            yield (read_stream, write_stream)
+        finally:
+            self._read_stream_writers.pop(session_id, None)
+
+
+def create_http_stream_server(mcp: FastMCP) -> Starlette:
+    """Create a Starlette app that handles HTTP streaming connections."""
+
+    transport: HttpStreamServerTransport | None = None
+
+    async def handle_stream(request: Request):
+        nonlocal transport
+        if transport is None:
+            server_url = f"{request.url.scheme}://{request.url.netloc}"
+            endpoint = f"{server_url}/http/messages/"
+            transport = HttpStreamServerTransport(endpoint)
+
+        async with transport.connect_stream(
+            request.scope, request.receive, request._send
+        ) as streams:
+            await mcp._mcp_server.run(
+                streams[0], streams[1], mcp._mcp_server.create_initialization_options()
+            )
+
+    routes = [
+        Route("/stream/", endpoint=handle_stream),
+        Mount(
+            "/messages/",
+            app=lambda scope, receive, send: transport.handle_post_message(
+                scope, receive, send
+            )
+            if transport
+            else None,
+        ),
+    ]
+
+    return Starlette(routes=routes)

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from app.sse import create_sse_server
+from app.http_stream import create_http_stream_server
 from mcp.server.fastmcp import FastMCP
 
 app = FastAPI()
@@ -7,6 +8,8 @@ mcp = FastMCP("MCP-SSE")
 
 # Mount the Starlette SSE server onto the FastAPI app
 app.mount("/", create_sse_server(mcp))
+# Mount HTTP streaming server under /http
+app.mount("/http", create_http_stream_server(mcp))
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- add `HttpStreamServerTransport` implementation
- expose `/http` streaming endpoints and mount them in the app
- document new endpoints in README

## Testing
- `python -m compileall -q app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fd77501883239af330712fb3ef28